### PR TITLE
Countries without currency symbol won't get loaded

### DIFF
--- a/country_data/src/main/java/com/blongho/country_data/Currency.java
+++ b/country_data/src/main/java/com/blongho/country_data/Currency.java
@@ -39,13 +39,13 @@ public class Currency {
   private final String country;   //The alpha2 value of the country
   private final String name;//The full name of the currency
   private final String code;//The currency code
-  private final String symbol;//The currency Symbol
+  private final String symbol;//The currency Symbol (optional)
 
   /**
    * @param countryCode  The alpha2 value of the country
    * @param currencyName The full name of the currency
    * @param currencyCode The currency code
-   * @param symbol       The currency Symbol
+   * @param symbol       The currency Symbol (optional)
    */
   Currency(
       String countryCode, String currencyName, String currencyCode, String symbol) {

--- a/country_data/src/main/java/com/blongho/country_data/WorldData.java
+++ b/country_data/src/main/java/com/blongho/country_data/WorldData.java
@@ -134,8 +134,7 @@ final class WorldData {
   }
 
   private boolean isValid(final Currency currency) {
-    return currency != null && currency.getSymbol() != null && currency.getName() != null
-        && currency.getCode() != null;
+    return currency != null && currency.getName() != null && currency.getCode() != null;
   }
 
   /**


### PR DESCRIPTION
**Describe the bug**
Countries like Guernsey (alpha2: `GG`) won't load correctly at all.
E.g. the world flag will be returned, instead of its own flag, which is included in this library.

The cause is this:
All those countries don't contain a `symbol` in `com_blongho_country_data_currencies.json`:
`HK`, `AN`, `TP`, `ID`, `PF`, `NC`, `WF`, `GI`, `MO`, `TM`, `AQ`, `GH`, `GG`, `MO`, `MF`

When initiating the countries, the `isValid(final Currency currency)` method returns `false` in those cases, as `currency.getSymbol() != null` is checked.

This pull requests fixes this issue by removing that single check.
You can also deny this request, keep the check and add a symbol to the mentioned elements in the json file.

I'm fine with either. 👍 

