### PR TITLE
Make classes "Country" and "Currency" Parcelable and fix spelling error in *Continent* Enum

### DIFF
--- a/country_data/src/main/java/com/blongho/country_data/Country.java
+++ b/country_data/src/main/java/com/blongho/country_data/Country.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * @since 2020-02-29
  **/
 
-public class Country {
+public class Country implements Serializable {
 
   private final static Map<String, String> CONTINENTS = Collections
       .unmodifiableMap(new HashMap<String, String>() {

--- a/country_data/src/main/java/com/blongho/country_data/Country.java
+++ b/country_data/src/main/java/com/blongho/country_data/Country.java
@@ -25,6 +25,8 @@
 
 package com.blongho.country_data;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IntegerRes;
 import androidx.annotation.NonNull;
@@ -33,18 +35,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * A country is represented by the name, the 2 letter representation, the 3 letter representation
- * <br>The Country data were gotten from the sister project by same author from
- * https://github.com/blongho/countries <br>A sample entry of the file is { "id": "020", "alpha2":
- * "AD", "alpha3": "AND", "name": "Andorra", "capital": "Andorra la Vella", "area": "468.0",
- * "population": "84,000", "continent": "EU" } * <p>The user should not be able to create a new
- * Country as in real life, countries are not just created. </p>
+ * A country is represented by the name, the 2 letter representation, the 3
+ * letter representation
+ * <br>
+ * The Country data were gotten from the sister project by same author from
+ * https://github.com/blongho/countries <br>
+ * A sample entry of the file is { "id": "020", "alpha2":
+ * "AD", "alpha3": "AND", "name": "Andorra", "capital": "Andorra la Vella",
+ * "area": "468.0",
+ * "population": "84,000", "continent": "EU" } *
+ * <p>
+ * The user should not be able to create a new
+ * Country as in real life, countries are not just created.
+ * </p>
  *
  * @author Bernard Che Longho (blongho)
  * @since 2020-02-29
  **/
 
-public class Country implements Serializable {
+public class Country implements Parcelable {
 
   private final static Map<String, String> CONTINENTS = Collections
       .unmodifiableMap(new HashMap<String, String>() {
@@ -59,10 +68,10 @@ public class Country implements Serializable {
           put("UNX", "Universe"); // Dummy for World
         }
       });
-  private final String id;        // The country's ISO 3166-1 numeric id
-  private final String name;        // The official name of the country
-  private final String alpha2;    // The country's ISO 3166 alpha2 id
-  private final String alpha3;    // The country's ISO 3166 alpha3 id
+  private final String id; // The country's ISO 3166-1 numeric id
+  private final String name; // The official name of the country
+  private final String alpha2; // The country's ISO 3166 alpha2 id
+  private final String alpha3; // The country's ISO 3166 alpha3 id
   private final String capital;
   private final String continent;
   private final String area;
@@ -96,6 +105,50 @@ public class Country implements Serializable {
     this.population = population;
     this.flagResource = flagResource;
     this.currency = currency;
+  }
+
+  protected Country(Parcel in) {
+    id = in.readString();
+    name = in.readString();
+    alpha2 = in.readString();
+    alpha3 = in.readString();
+    capital = in.readString();
+    continent = in.readString();
+    area = in.readString();
+    population = in.readString();
+    flagResource = in.readInt();
+    currency = in.readParcelable(Currency.class.getClassLoader());
+  }
+
+  public static final Creator<Country> CREATOR = new Creator<Country>() {
+    @Override
+    public Country createFromParcel(Parcel in) {
+      return new Country(in);
+    }
+
+    @Override
+    public Country[] newArray(int size) {
+      return new Country[size];
+    }
+  };
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel parcel, int flags) {
+    parcel.writeString(id);
+    parcel.writeString(name);
+    parcel.writeString(alpha2);
+    parcel.writeString(alpha3);
+    parcel.writeString(capital);
+    parcel.writeString(continent);
+    parcel.writeString(area);
+    parcel.writeString(population);
+    parcel.writeInt(flagResource);
+    parcel.writeParcelable(currency, flags);
   }
 
   /**
@@ -217,7 +270,8 @@ public class Country implements Serializable {
   }
 
   /**
-   * Format area and population data to a suitable way so that it can be parsed to Integral types
+   * Format area and population data to a suitable way so that it can be parsed to
+   * Integral types
    *
    * @param unformatted The unformatted string {xx,xxx,xxx,xxx}
    * @return a string with all commas (,) removed

--- a/country_data/src/main/java/com/blongho/country_data/Currency.java
+++ b/country_data/src/main/java/com/blongho/country_data/Currency.java
@@ -25,21 +25,26 @@
 
 package com.blongho.country_data;
 
+import android.os.Parcel;
+import android.os.Parcelable;
 import androidx.annotation.NonNull;
 
 /**
  * The currency of a {@link Country}
- * <p>A {@link Currency} can not be instantiated but only obtained from a {@link Country}</p>
+ * <p>
+ * A {@link Currency} can not be instantiated but only obtained from a
+ * {@link Country}
+ * </p>
  *
  * @author Bernard Che Longho (blongho)
  * @since 2019-11-15
  */
-public class Currency {
+public class Currency implements Parcelable {
 
-  private final String country;   //The alpha2 value of the country
-  private final String name;//The full name of the currency
-  private final String code;//The currency code
-  private final String symbol;//The currency Symbol
+  private final String country; // The alpha2 value of the country
+  private final String name;// The full name of the currency
+  private final String code;// The currency code
+  private final String symbol;// The currency Symbol
 
   /**
    * @param countryCode  The alpha2 value of the country
@@ -54,6 +59,38 @@ public class Currency {
     this.name = currencyName;
     this.code = currencyCode;
     this.symbol = symbol;
+  }
+
+  protected Currency(Parcel in) {
+    country = in.readString();
+    name = in.readString();
+    code = in.readString();
+    symbol = in.readString();
+  }
+
+  public static final Creator<Currency> CREATOR = new Creator<Currency>() {
+    @Override
+    public Currency createFromParcel(Parcel in) {
+      return new Currency(in);
+    }
+
+    @Override
+    public Currency[] newArray(int size) {
+      return new Currency[size];
+    }
+  };
+
+  @Override
+  public int describeContents() {
+    return 0;
+  }
+
+  @Override
+  public void writeToParcel(Parcel parcel, int flags) {
+    parcel.writeString(country);
+    parcel.writeString(name);
+    parcel.writeString(code);
+    parcel.writeString(symbol);
   }
 
   /**
@@ -92,7 +129,6 @@ public class Currency {
     result = 31 * result + (symbol != null ? symbol.hashCode() : 0);
     return result;
   }
-
 
   @Override
   public boolean equals(final Object o) {

--- a/country_data/src/main/java/com/blongho/country_data/World.java
+++ b/country_data/src/main/java/com/blongho/country_data/World.java
@@ -194,7 +194,7 @@ public final class World {
     AFRICA("Africa"),
     EUROPE("Europe"),
     ASIA("Asia"),
-    OCEANA("Oceania"),
+    OCEANIA("Oceania"),
     SOUTH_AMERICA("South America"),
     NORTH_AMERICA("North America"),
     ANTARTICA("Antarctica");


### PR DESCRIPTION
When trying to send for example a `List<Country>` from one activity to another via *Intents*, my application was crashing due to the fact that the class `Country` was not Parcelable. This pull request is my attempt to make the classes `Country` and `Currency` (*Currency* needs to be Parcelable too otherwise *Country* can't write *Currency* objects to it's Parcel) *Parcelable* in order to allow for the described functionality to work without crashing.

Furthermore I noticed a spelling error in the *enum* regarding the continents, so I fixed that.